### PR TITLE
Use correct variable for graphs.ini

### DIFF
--- a/roles/icingaweb2_modules/tasks/configure_grafana.yml
+++ b/roles/icingaweb2_modules/tasks/configure_grafana.yml
@@ -61,7 +61,7 @@
 - name: Deploy graphs.ini
   become: true
   vars:
-    _graphs: "{{ _module.graphs | default({}) | dict2items }}"
+    _graphs: "{{ _module.config.graphs | default({}) | dict2items }}"
   when: _graphs
   ansible.builtin.template:
     src: "{{ role_path }}/templates/grafana/graphs.ini.j2"


### PR DESCRIPTION
Use 'icingaweb2_modules.grafana.config.graphs' instead of 'icingaweb2_modules.grafana.graphs' when templating graphs.ini

Fixes #1