### PR TITLE
Add ability to merge *.ini files into graphs.ini

### DIFF
--- a/roles/icingaweb2_modules/README.md
+++ b/roles/icingaweb2_modules/README.md
@@ -69,6 +69,11 @@ Table of contents:
   - `import_dashboards`: `boolean`  
     Whether to import the dashboards provided by the module into your Grafana server.  
     Default: `false`
+  - `import_graphs_ini`: `boolean`  
+    Whether to import all \*.ini files within the `local_dashboards` directory to be part of **graphs.ini**.  
+    With this you can provide parts of graphs.ini without having to convert existing \*.ini files to YAML.  
+    `config.graphs` **takes precedence** over the \*.ini files when redefining the same section.  
+    Default: `false`
   - `config.grafana`: `dictionary`  
     Manages *config.ini* to configure the module. Its keys are equal to the modules [configuration file](https://github.com/Mikesch-mp/icingaweb2-module-grafana/blob/master/doc/03-module-configuration.md#example-configini-etcicingaweb2modulesgrafanaconfigini), though not necessarily complete yet.  
     For possible default values have look at [templates/grafana/config.ini.j2](templates/grafana/config.ini.j2).

--- a/roles/icingaweb2_modules/tasks/configure_grafana.yml
+++ b/roles/icingaweb2_modules/tasks/configure_grafana.yml
@@ -6,6 +6,12 @@
     - icingaweb2_modules.grafana.import_dashboards | default(false)
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/configure_grafana_dashboards.yml"
 
+- name: Configure graphs.ini
+  when:
+    - icingaweb2_modules.grafana.local_dashboards is defined
+    - icingaweb2_modules.grafana.import_graphs_ini | default(false)
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/configure_graphs_ini.yml"
+
 - name: Check if folder uid can be fetched
   when:
     - icingaweb2_modules.grafana.config.grafana.host is defined
@@ -61,7 +67,7 @@
 - name: Deploy graphs.ini
   become: true
   vars:
-    _graphs: "{{ _module.config.graphs | default({}) | dict2items }}"
+    _graphs: "{{ _all_graphs_ini | default({}) | combine(_module.config.graphs | default({})) | dict2items }}"
   when: _graphs
   ansible.builtin.template:
     src: "{{ role_path }}/templates/grafana/graphs.ini.j2"

--- a/roles/icingaweb2_modules/tasks/configure_graphs_ini.yml
+++ b/roles/icingaweb2_modules/tasks/configure_graphs_ini.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Find all local .ini files
+  run_once: true
+  ansible.builtin.set_fact:
+    _local_graphs_ini: "{{ lookup('ansible.builtin.fileglob', icingaweb2_modules.grafana.local_dashboards + '/*.ini', wantlist=true) }}"
+
+- name: Read contents of local graphs.ini files
+  run_once: true
+  delegate_to: localhost
+  loop: "{{ _local_graphs_ini }}"
+  ansible.builtin.slurp:
+    src: "{{ item }}"
+  register: "_local_graphs_ini_contents"
+
+- name: Combine all .ini files into a dictionary
+  run_once: true
+  loop: "{{ _local_graphs_ini_contents.results }}"
+  set_fact:
+    _all_graphs_ini: "{{ _all_graphs_ini | default({}) | combine(item.content | b64decode | replace('\"', '') | community.general.from_ini) }}"


### PR DESCRIPTION
When providing 'local_dashboards' and setting 'import_graphs_ini' within the definitions for the grafana module, all *.ini files within the 'local_dashboards' directory are merged with the key 'icingaweb2_modules.grafana.config.graphs' to be able to provide information for graphs.ini via pre-written *.ini files.

In short; you don't have to convert existing graphs.ini files to YAML in order to use them.

Fixes #2