### PR TITLE
Add modules map and mapdatatype by nbuchwitz

### DIFF
--- a/roles/icingaweb2_modules/README.md
+++ b/roles/icingaweb2_modules/README.md
@@ -16,8 +16,12 @@ Table of contents:
 * [Variables](#variables)
   * [General](#general)
   * [Grafana](#grafana)
+  * [Map](#map)
+  * [Map Datatype](#map-datatype)
 * [Example Playbooks](#example-playbooks)
   * [Grafana Playbooks](#grafana-playbooks)
+  * [Map Playbooks](#map-playbooks)
+  * [Map Datatype Playbooks](#map-datatype-playbooks)
 
 # Variables
 
@@ -87,6 +91,21 @@ Table of contents:
 - `icingaweb2_modules_grafana_server_dashboard_path`: `string`  
   The path where imported dashboards should be deployed on your Grafana server.  
   Default: `/var/lib/grafana/dashboards/icingaweb2-grafana`
+
+## Map
+
+- `icingaweb2_modules.map`: `dictionary`  
+  - `config.map`: `dictionary`  
+    Manages the section `map` within *config.ini* to configure the module. Its keys are equal to the module's [settings](https://github.com/nbuchwitz/icingaweb2-module-map/blob/master/doc/03-Exploring-the-map.md#settings).  
+    For possible default values have look at [templates/map/config.ini.j2](templates/map/config.ini.j2).
+  - `config.director`: `dictionary`  
+    Manages the section `director` within *config.ini* to configure the module. It shares some keys with `config.map`.  
+    Have a look at [templates/map/config.ini.j2](templates/map/config.ini.j2).
+
+## Map Datatype
+
+- `icingaweb2_modules.mapDatatype`: `none`  
+  - No keys for this module.
 
 # Example Playbooks
 
@@ -182,4 +201,38 @@ Install grafana module via Git and configure connection to Grafana server. Also 
 
   roles:
     - netways.icinga_contrib.icingaweb2_modules
+```
+
+## Map Playbooks
+
+Install the map module via Git and set it to show the number of problems in a clustered view instead of the number of markers within that cluster.
+
+```yaml
+- name: Manage map module
+  hosts:
+    - icingaweb2
+
+  vars:
+    icingaweb2_modules:
+      map:
+        config:
+          map:
+            cluster_problem_count: 1
+```
+
+## Map Datatype Playbooks
+
+Install the mapDatatype module via Git.
+
+```yaml
+- name: Manage mapDatatype module
+  hosts:
+    - icingaweb2
+
+  vars:
+    icingaweb2_modules:
+      mapDatatype:
+        package_name: "icinga-mapdatatype"
+        source: git
+        url: "https://github.com/nbuchwitz/icingaweb2-module-mapDatatype.git"
 ```

--- a/roles/icingaweb2_modules/tasks/configure_map.yml
+++ b/roles/icingaweb2_modules/tasks/configure_map.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Deploy config.ini
+  become: true
+  vars:
+    _map: "{{ _module.config.map | default(omit) }}"
+    _director: "{{ _module.config.director | default(omit) }}"
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/map/config.ini.j2"
+    dest: "{{ icingaweb2_modules_config_path }}/modules/map/config.ini"
+    owner: "{{ _icingaweb2_modules_web2_user }}"
+    group: "{{ _icingaweb2_modules_web2_group }}"
+    mode: "0660"

--- a/roles/icingaweb2_modules/templates/map/config.ini.j2
+++ b/roles/icingaweb2_modules/templates/map/config.ini.j2
@@ -1,0 +1,60 @@
+[map]
+{% set _stateType = "soft" %}
+{% set _cluster_problem_count = "0" %}
+{% set _popup_mouseover = "0" %}
+{% if _map.default_zoom is defined %}
+default_zoom = "{{ _map.default_zoom }}"
+{% endif %}
+stateType = "{{ _map.stateType | default(_stateType) }}"
+cluster_problem_count = "{{ _map.cluster_problem_count | default(_cluster_problem_count) }}"
+popup_mouseover = "{{ _map.popup_mouseover | default(_popup_mouseover) }}"
+{% if _map.default_lat is defined %}
+default_lat = "{{ _map.default_lat }}"
+{% endif %}
+{% if _map.default_long is defined %}
+default_long = "{{ _map.default_long }}"
+{% endif %}
+{% if _map.max_zoom is defined %}
+max_zoom = "{{ _map.max_zoom }}"
+{% endif %}
+{% if _map.max_native_zoom is defined %}
+max_native_zoom = "{{ _map.max_native_zoom }}"
+{% endif %}
+{% if _map.min_zoom is defined %}
+min_zoom = "{{ _map.min_zoom }}"
+{% endif %}
+{% if _map.tile_url is defined %}
+tile_url = "{{ _map.tile_url }}"
+{% endif %}
+{% if _map.opencage_apikey is defined %}
+opencage_apikey = "{{ _map.opencage_apikey }}"
+{% endif %}
+{% if _map.dashlet_height is defined %}
+dashlet_height = "{{ _map.dashlet_height }}"
+{% endif %}
+{% if _map.disable_cluster_at_zoom is defined %}
+disable_cluster_at_zoom = "{{ _map.disable_cluster_at_zoom }}"
+{% endif %}
+
+[director]
+{% if _director.default_lat is defined %}
+default_lat = "{{ _director.default_lat }}"
+{% endif %}
+{% if _director.default_long is defined %}
+default_long = "{{ _director.default_long }}"
+{% endif %}
+{% if _director.default_zoom is defined %}
+default_zoom = "{{ _director.default_zoom }}"
+{% endif %}
+{% if _director.max_zoom is defined %}
+max_zoom = "{{ _director.max_zoom }}"
+{% endif %}
+{% if _director.max_native_zoom is defined %}
+max_native_zoom = "{{ _director.max_native_zoom }}"
+{% endif %}
+{% if _director.min_zoom is defined %}
+min_zoom = "{{ _director.min_zoom }}"
+{% endif %}
+{% if _director.tile_url is defined %}
+tile_url = "{{ _director.tile_url }}"
+{% endif %}

--- a/roles/icingaweb2_modules/vars/main.yml
+++ b/roles/icingaweb2_modules/vars/main.yml
@@ -3,6 +3,8 @@
 # List of modules known to this role
 _icingaweb2_modules_known_modules:
   - "grafana"
+  - "map"
+  - "mapDatatype"
 
 _icingaweb2_modules_grafana_server_user: "grafana"
 _icingaweb2_modules_grafana_server_group: "grafana"


### PR DESCRIPTION
Add the modules map and mapdatatype. The first one allows you to mark your hosts on a world map using openstreetmap.

The latter adds a datatype to the Icinga Director that lets you pick geolocation data on the map and set longitude and latitude as a variable.