### PR TITLE
Add default git urls to known modules

### DIFF
--- a/roles/icingaweb2_modules/tasks/configure_default.yml
+++ b/roles/icingaweb2_modules/tasks/configure_default.yml
@@ -1,0 +1,5 @@
+---
+
+- name: No configuration tasks
+  ansible.builtin.debug:
+    msg: "No configuration tasks available for module '{{ _current_module.key }}'"

--- a/roles/icingaweb2_modules/tasks/install_module.yml
+++ b/roles/icingaweb2_modules/tasks/install_module.yml
@@ -34,7 +34,7 @@
       become: true
       when: _module.source | lower == "git"
       ansible.builtin.git:
-        repo: "{{ _module.url }}"
+        repo: "{{ _module.url | default((_icingaweb2_modules_known_modules | selectattr('name', 'eq', _current_module.key) | first).git_url) }}"
         dest: "{{ icingaweb2_modules_path }}/{{ _module_name }}"
         version: "{{ _module.version | default(omit) }}"
   rescue:
@@ -48,7 +48,7 @@
       become: true
       when: _module.source | lower == "git"
       ansible.builtin.git:
-        repo: "{{ _module.url }}"
+        repo: "{{ _module.url | default((_icingaweb2_modules_known_modules | selectattr('name', 'eq', _current_module.key) | first).git_url) }}"
         dest: "{{ icingaweb2_modules_path }}/{{ _module_name }}"
         version: "{{ _module.version | default(omit) }}"
 

--- a/roles/icingaweb2_modules/tasks/main.yml
+++ b/roles/icingaweb2_modules/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Install Icinga Web 2 Module
   when:
     - icingaweb2_modules is defined
-    - _current_module.key in _icingaweb2_modules_known_modules
+    - _current_module.key in (_icingaweb2_modules_known_modules | map(attribute='name'))
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
     loop_var: _current_module
@@ -29,7 +29,7 @@
   become: true
   when:
     - icingaweb2_modules is defined
-    - _current_module.key in _icingaweb2_modules_known_modules
+    - _current_module.key in (_icingaweb2_modules_known_modules | map(attribute='name'))
     - _enabled != omit
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
@@ -51,7 +51,7 @@
   become: true
   when:
     - icingaweb2_modules is defined
-    - _current_module.key in _icingaweb2_modules_known_modules
+    - _current_module.key in (_icingaweb2_modules_known_modules | map(attribute='name'))
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
     loop_var: _current_module
@@ -65,10 +65,11 @@
 - name: Configure module
   when:
     - icingaweb2_modules is defined
-    - _current_module.key in _icingaweb2_modules_known_modules
+    - _current_module.key in (_icingaweb2_modules_known_modules | map(attribute='name'))
   loop: "{{ icingaweb2_modules | dict2items }}"
   loop_control:
     loop_var: _current_module
   vars:
     _module: "{{ icingaweb2_modules[_current_module.key] }}"
-  ansible.builtin.include_tasks: "{{ role_path }}/tasks/configure_{{ _current_module.key }}.yml"
+    _module_configure_tasks: "{{ lookup('ansible.builtin.first_found', role_path + '/tasks/configure_' + _current_module.key + '.yml', skip=True) | default(role_path + '/tasks/configure_default.yml', true) }}"
+  ansible.builtin.include_tasks: "{{ _module_configure_tasks }}"

--- a/roles/icingaweb2_modules/vars/main.yml
+++ b/roles/icingaweb2_modules/vars/main.yml
@@ -2,9 +2,12 @@
 
 # List of modules known to this role
 _icingaweb2_modules_known_modules:
-  - "grafana"
-  - "map"
-  - "mapDatatype"
+  - name: "grafana"
+    git_url: "https://github.com/Mikesch-mp/icingaweb2-module-grafana.git"
+  - name: "map"
+    git_url: "https://github.com/nbuchwitz/icingaweb2-module-map.git"
+  - name: "mapDatatype"
+    git_url: "https://github.com/nbuchwitz/icingaweb2-module-mapDatatype.git"
 
 _icingaweb2_modules_grafana_server_user: "grafana"
 _icingaweb2_modules_grafana_server_group: "grafana"


### PR DESCRIPTION
Adds the modules' git project urls to the modules to be able to serve default upstreams for the installation via git.

Users should not have to search for the urls themselves if they don't actually want to use a local mirror.

Fixes #5