### PR TITLE
Enable the usage of local custom modules

### DIFF
--- a/roles/icingaweb2_modules/README.md
+++ b/roles/icingaweb2_modules/README.md
@@ -54,6 +54,8 @@ Table of contents:
       The version / tag for Git installation (e.g. `version: "v2.0.2"`)
     - `enabled`: `boolean`  
       If `true`, enables the module. If `false`, disables the module. If not set, does nothing.
+    - `remote_src:` `boolean`
+      Set it to `false` to copy archive module from Ansible controller to target host. Useful when `source` set to `archive`. Defualt `true`.
 
 ## Grafana
 

--- a/roles/icingaweb2_modules/README.md
+++ b/roles/icingaweb2_modules/README.md
@@ -54,7 +54,7 @@ Table of contents:
       The version / tag for Git installation (e.g. `version: "v2.0.2"`)
     - `enabled`: `boolean`  
       If `true`, enables the module. If `false`, disables the module. If not set, does nothing.
-    - `remote_src:` `boolean`
+    - `remote_source:` `boolean`
       Set it to `false` to copy archive module from Ansible controller to target host. Useful when `source` set to `archive`. Defualt `true`.
 
 ## Grafana

--- a/roles/icingaweb2_modules/README.md
+++ b/roles/icingaweb2_modules/README.md
@@ -55,7 +55,9 @@ Table of contents:
     - `enabled`: `boolean`  
       If `true`, enables the module. If `false`, disables the module. If not set, does nothing.
     - `remote_source:` `boolean`
-      Set it to `false` to copy archive module from Ansible controller to target host. Useful when `source` set to `archive`. Defualt `true`.
+      If set to `false`, the archive is copied from the Ansible controller to the managed node. Only has an effect if `source` is set to `archive`.  
+      This is useful when the managed node cannot freely access the given URL, e.g. no access to the internet.  
+      Default: `true`
 
 ## Grafana
 

--- a/roles/icingaweb2_modules/tasks/install_module.yml
+++ b/roles/icingaweb2_modules/tasks/install_module.yml
@@ -70,6 +70,6 @@
       ansible.builtin.unarchive:
         src: "{{ _module.url }}"
         dest: "{{ icingaweb2_modules_path }}/{{ _module_name }}"
-        remote_src: true
+        remote_src: "{{ _module.remote_source | default('true') }}"
         extra_opts:
           - "--strip-components=1"

--- a/roles/icingaweb2_modules/tasks/install_module.yml
+++ b/roles/icingaweb2_modules/tasks/install_module.yml
@@ -70,6 +70,6 @@
       ansible.builtin.unarchive:
         src: "{{ _module.url }}"
         dest: "{{ icingaweb2_modules_path }}/{{ _module_name }}"
-        remote_src: "{{ _module.remote_source | default('true') }}"
+        remote_src: "{{ _module.remote_source | default(true) }}"
         extra_opts:
           - "--strip-components=1"


### PR DESCRIPTION
With this change the users can use Ansible controller as a source for the archived Icingaweb 2 modules. Some users or customers does not have access to internet to install custom modules on the target hosts.